### PR TITLE
Fixed bad URL in CONTRIBUTING.md

### DIFF
--- a/src/development/CONTRIBUTING.md
+++ b/src/development/CONTRIBUTING.md
@@ -29,4 +29,4 @@ Development:
 
 
 [//]: <> (urls)
-[Semantic Line Breaks]: https://docs.fluidattacks.com/development/writing/slb/
+[Semantic Line Breaks]: https://web.archive.org/web/20230929101316/https://docs.fluidattacks.com/development/writing/slb/


### PR DESCRIPTION
The current URL gives a 404. However, archive.org has a snapshot of the web page.